### PR TITLE
feat(shipping): selector región/comuna + normalización de teléfono

### DIFF
--- a/cart.html
+++ b/cart.html
@@ -24,7 +24,7 @@
         <li class="nav-item"><a class="nav-link" href="catalogo.html">Productos</a></li>
       </ul>
 
-      <!-- Buscador global: redirige a catalogo.html?q=... -->
+      <!-- Buscador global: redirige a catalogo.html -->
       <form class="d-none d-lg-flex me-lg-3" action="catalogo.html" method="get" role="search">
         <div class="input-group nav-search">
           <span class="input-group-text bg-transparent border-end-0"><i class="bi bi-search"></i></span>
@@ -49,12 +49,12 @@
   <main class="container py-4">
   <h1 class="h4 mb-3">Carrito</h1>
 
-  <!-- estado vacío -->
+  <!-- Estado vacío -->
   <div id="empty" class="alert alert-info d-none">
     Tu carrito está vacío. <a href="catalogo.html" class="alert-link">Ir al catálogo</a>.
   </div>
 
-  <!-- contenido -->
+  <!-- Contenido -->
   <div id="cartWrap" class="row g-4 d-none">
     <!-- Lista de productos -->
     <section class="col-12 col-lg-8">
@@ -126,7 +126,7 @@
     </div>
   </div>
 
-  <!-- Toasts (mismo que usas en otras páginas) -->
+  <!-- Toasts (mismo que se usa en otras páginas) -->
   <div class="position-fixed bottom-0 end-0 p-3" style="z-index:1080">
     <div id="appToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">
       <div class="toast-header">
@@ -140,6 +140,7 @@
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script>
+  
   // tema claro/oscuro
   (function () {
     const root = document.documentElement;

--- a/catalogo.html
+++ b/catalogo.html
@@ -158,7 +158,9 @@
               </div>
             </div>
 
-          </div><!-- /accordion -->
+          </div>
+        
+          <!-- /accordion -->
 
           <button id="clear" class="btn btn-sm btn-outline-secondary w-100 mt-3">Limpiar filtros</button>
         </div>

--- a/checkout.html
+++ b/checkout.html
@@ -24,7 +24,7 @@
         <li class="nav-item"><a class="nav-link" href="catalogo.html">Productos</a></li>
       </ul>
 
-      <!-- Buscador global: redirige a catalogo.html?q=... -->
+      <!-- Buscador global: redirige a catalogo.html -->
       <form class="d-none d-lg-flex me-lg-3" action="catalogo.html" method="get" role="search">
         <div class="input-group nav-search">
           <span class="input-group-text bg-transparent border-end-0"><i class="bi bi-search"></i></span>
@@ -101,10 +101,11 @@
             <!-- Envío -->
             <h2 class="h6 mb-3">Tipo de envío</h2>
 
-            <!-- Selector de envío compatible con tu checkout.js -->
+            <!-- Selector de envío compatible con el checkout.js -->
             <div class="mb-3">
               <label class="form-label" for="shipping">Método de envío</label>
               <select id="shipping" class="form-select" required>
+
               <!-- Se llena con fillShippingSelect() -->
               </select>
             </div>
@@ -147,7 +148,7 @@
     Pagar con tarjeta
   </label>
 
-  <!-- Caja de tarjeta (se muestra solo si eliges "card") -->
+  <!-- Caja de tarjeta (se muestra solo si se elige "card") -->
   <div id="cardBox" class="border rounded p-3 mt-2 d-none">
     <div class="row g-2">
       <div class="col-12">
@@ -176,7 +177,7 @@
     Transferencia bancaria
   </label>
 
-  <!-- Nota: mantengo id="instBox" por compatibilidad -->
+  <!-- Nota: se mantiene id="instBox" por compatibilidad -->
   <div id="instBox" class="border rounded p-3 mt-2 d-none">
     <div class="small text-muted">
       Al confirmar el pedido verás los datos de la cuenta y tu número de orden para realizar la transferencia.
@@ -269,6 +270,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script>
+
   // === Tema claro/oscuro
   (function () {
     const root = document.documentElement;
@@ -291,8 +293,8 @@
   })();
 
   // === Toggle método de pago: tarjeta / transferencia
-  // - Muestra #cardBox si eliges "card"
-  // - Muestra #instBox (transferencia) si eliges "bank"
+  // - Muestra #cardBox si se elige "card"
+  // - Muestra #instBox (transferencia) si se elige "bank"
   
   (function () {
     const run = () => {

--- a/favoritos.html
+++ b/favoritos.html
@@ -3,7 +3,7 @@
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Mini-Amazon | Favoritos</title>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-<link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet"><!-- íconos -->
+<link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet"> <!-- íconos -->
 <link href="css/styles.css" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
 </head>
@@ -22,7 +22,7 @@
         <li class="nav-item"><a class="nav-link" href="catalogo.html">Productos</a></li>
       </ul>
 
-      <!-- Buscador global: redirige a catalogo.html?q=... -->
+      <!-- Buscador global: redirige a catalogo.html -->
       <form class="d-none d-lg-flex me-lg-3" action="catalogo.html" method="get" role="search">
         <div class="input-group nav-search">
           <span class="input-group-text bg-transparent border-end-0"><i class="bi bi-search"></i></span>
@@ -49,6 +49,7 @@
 </main>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script>
+  
   // tema claro/oscuro
   (function () {
     const root = document.documentElement;

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
   <!-- Fuente (títulos) -->
   <link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
 
-  <!-- Tus estilos -->
+  <!-- Estilos -->
   <link href="/css/styles.css" rel="stylesheet">
 </head>
 <body>
@@ -30,7 +30,7 @@
         <li class="nav-item"><a class="nav-link" href="catalogo.html">Productos</a></li>
       </ul>
 
-      <!-- Buscador global: redirige a catalogo.html?q=... -->
+      <!-- Buscador global: redirige a catalogo.html -->
       <form class="d-none d-lg-flex me-lg-3" action="catalogo.html" method="get" role="search">
         <div class="input-group nav-search">
           <span class="input-group-text bg-transparent border-end-0"><i class="bi bi-search"></i></span>
@@ -166,6 +166,7 @@
 <script type="module" src="/js/app.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script>
+  
   // tema claro/oscuro
   (() => {
     const root = document.documentElement;

--- a/js/cart.js
+++ b/js/cart.js
@@ -1,7 +1,7 @@
 import { getJSON } from "./api.js";
 import { toast }   from "./app.js";
 
-// --- Normalizador (mismo que en producto.js) ---
+// --- Normalizador ---
 function normalizeProduct(p) {
   return {
     id: p.id,
@@ -43,7 +43,7 @@ function enableImageFallback(rootSelector) {
 // --- Estado ---
 const state = {
   products: [],    // normalizados
-  cart: readCart(),// { items:[{productId, qty}] }
+  cart: readCart(),   // { items:[{productId, qty}] }
   pendingRemove: null
 };
 

--- a/js/catalogo.js
+++ b/js/catalogo.js
@@ -31,7 +31,7 @@ const state = {
     brand: "",
     pricePreset: "all",
     rating: null,
-    favOnly: false,   // si luego activas “Solo favoritos” desde UI
+    favOnly: false,   // si luego se activa “Solo favoritos” desde UI
     sort: "relevance",
     inStock: false
   }
@@ -255,15 +255,15 @@ function wireFilters(cats) {
     });
   }
 
-  // búsqueda con datalist (si existe)
+  // búsqueda con datalist
   on("q", "input", (()=>{ let t; return (e)=>{ clearTimeout(t); t=setTimeout(()=>{ state.filter.q=e.target.value; updateSuggestions(); renderGrid(); },250);} })());
 
-  // rating, stock, sort (si existen)
+  // rating, stock, sort
   on("rating", "change", (e)=>{ state.filter.rating = e.target.value || null; renderGrid(); });
   on("stockOnly","change", (e)=>{ state.filter.inStock = e.target.checked; renderGrid(); });
   on("sort",   "change", (e)=>{ state.filter.sort = e.target.value; renderGrid(); });
 
-  // limpiar (si existe)
+  // limpiar
   on("clear","click", ()=>{
     state.filter = { q:"", cat:"", brand:"", pricePreset:"all", rating:null, favOnly:false, sort:"relevance", inStock:false };
     if ($id("q"))      $id("q").value = "";
@@ -279,7 +279,7 @@ function wireFilters(cats) {
     renderGrid();
   });
 
-  // Delegación en grid: favs y quick view (si existe grid)
+  // Delegación en grid: favs y quick view (donde existe grid)
   const grid = $id("grid");
   if (grid) {
     document.getElementById("grid").addEventListener("click", (e) => {

--- a/js/checkout.js
+++ b/js/checkout.js
@@ -111,7 +111,7 @@ function aplicarCupon(code, allCoupons){
   const show = (text, cls) => {
     if (!msg) return;
     msg.textContent = text;
-    msg.className = "form-text " + cls; // reemplaza clases (quita d-none si estaba)
+    msg.className = "form-text " + cls; // reemplaza clases (quita d-none)
   };
 
   const c = String(code||"").trim().toUpperCase();
@@ -121,14 +121,14 @@ function aplicarCupon(code, allCoupons){
     state.coupon = null;
     show("Cupón inválido.", "text-danger");
     toast("Cupón inválido", "danger");
-    renderSummary();               // <— vuelve a pintar totales SIN descuento
+    renderSummary();    // <— vuelve a pintar totales SIN descuento
     return;
   }
 
-  state.coupon = found;            // {code, type: 'fixed'|'percent'|'ship', value}
+  state.coupon = found;    // {code, type: 'fixed'|'percent'|'ship', value}
   show(`Cupón aplicado: ${found.code}`, "text-success");
   toast("Cupón aplicado", "success");
-  renderSummary();                 // <— repinta con descuento/envío gratis
+  renderSummary();    // <— repinta con descuento/envío gratis
 }
 
 function wireCoupon(coupons){
@@ -250,7 +250,7 @@ function renderSummary() {
   set("iva",      fmtCLP(iva));
   set("total",    fmtCLP(total));
 
-  // (si usas panel derecho alternativo)
+  // (Panel derecho alternativo)
   set("coSub",   fmtCLP(subtotal));
   set("coDisc",  discount ? "−" + fmtCLP(discount) : fmtCLP(0));
   set("coShip",  fmtCLP(ship));
@@ -404,7 +404,7 @@ function genCaptcha(){
 function wirePaymentRadios(){
   const radios  = document.querySelectorAll('input[name="paymethod"]');
   const cardBox = document.getElementById('cardBox'); // tarjeta
-  const bankBox = document.getElementById('instBox'); // transferencia (mantenido id)
+  const bankBox = document.getElementById('instBox'); // transferencia 
   const reqIds  = ['ccNumber','ccExp','ccCvc','cardNumber','cardExp','cardCvv']; // soporta ambos
 
   function toggle(){
@@ -448,8 +448,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   // ---------- Cupones ----------
   const coupons = await loadCoupons();
-  wireCoupon(coupons);               // <— usa la función de arriba
-// Si quieres que al teclear se re-evalúe el botón Confirmar:
+  wireCoupon(coupons);   // <— usa la función de arriba
   document.getElementById("couponCode")?.addEventListener("input", () => {
   const btn = document.getElementById("btnPlace");
   if (btn) btn.disabled = !validateForm(false);
@@ -498,7 +497,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   document.querySelectorAll('input[name="paymethod"]').forEach(r =>
     r.addEventListener("change", enable)
   );
-  wireExpressPay?.();     // si tienes esta función en tu archivo
+  wireExpressPay?.();     // se cumple esta función en el archivo
   // Asegura enable() al elegir un express
   document.querySelectorAll('[data-pay]').forEach(btn =>
     btn.addEventListener("click", () => setTimeout(enable, 0))

--- a/js/producto.js
+++ b/js/producto.js
@@ -394,7 +394,7 @@ async function init() {
       qtyInput.addEventListener(evt, () => setQty(qtyInput.value));
     });
 
-// (Opcional) si no hay stock, bloquea
+// (Opcional) Si no hay stock, se bloquea
     if (Number(p.stock) <= 0) {
       qtyInput.value = "0";
       qtyInput.disabled = true;
@@ -419,7 +419,7 @@ async function init() {
 }
 
 async function cargarResenas() {
-    const id = getParam("id");                 // viene de producto.html?id=ALGO
+    const id = getParam("id");   // viene de producto.html
         if (!id) return;
     
     const [productos, reviews] = await Promise.all([

--- a/orders.html
+++ b/orders.html
@@ -24,7 +24,7 @@
         <li class="nav-item"><a class="nav-link" href="catalogo.html">Productos</a></li>
       </ul>
 
-      <!-- Buscador global: redirige a catalogo.html?q=... -->
+      <!-- Buscador global: redirige a catalogo.html -->
       <form class="d-none d-lg-flex me-lg-3" action="catalogo.html" method="get" role="search">
         <div class="input-group nav-search">
           <span class="input-group-text bg-transparent border-end-0"><i class="bi bi-search"></i></span>
@@ -53,6 +53,7 @@
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 <script>
+  
   // tema claro/oscuro
   (function () {
     const root = document.documentElement;

--- a/producto.html
+++ b/producto.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Mini-Amazon | Producto</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet"><!-- íconos -->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet"> <!-- íconos -->
   <link href="css/styles.css" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
 </head>
@@ -24,7 +24,7 @@
         <li class="nav-item"><a class="nav-link" href="catalogo.html">Productos</a></li>
       </ul>
 
-      <!-- Buscador global: redirige a catalogo.html?q=... -->
+      <!-- Buscador global: redirige a catalogo.html -->
       <form class="d-none d-lg-flex me-lg-3" action="catalogo.html" method="get" role="search">
         <div class="input-group nav-search">
           <span class="input-group-text bg-transparent border-end-0"><i class="bi bi-search"></i></span>
@@ -145,6 +145,7 @@
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <script>
+    
   // tema claro/oscuro
   (function () {
     const root = document.documentElement;


### PR DESCRIPTION
Closes #5

### Qué hace
- Carga regiones/comunas desde `localidades.json`.
- Dependencia: al cambiar región, se resetea la comuna.
- Input de teléfono: solo `+` y dígitos; validación 8–15.

### Cómo probar
1) Cambiar región → comuna vuelve a “Selecciona…”.
2) Escribir teléfono con/ sin `+`; probar menos de 8 dígitos → inválido.
3) Completar datos y confirmar pedido.

### Checklist
- [x] Validaciones visuales con `is-invalid`.
- [x] Sin errores en consola.